### PR TITLE
Scan command

### DIFF
--- a/artorias.py
+++ b/artorias.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 
-"""Artorias main file, kicks off the rest of the project"""
+"""
+Artorias main file, kicks off the rest of the project. Either run scan(s) individually with
+the scan arg, or run all of them with the test arg.
+"""
 
 import logging
 from core.args import parse_cmd
 from core.testing import handle_test
+from core.scanning import handle_scan
 
 def main() -> int:
     """
-        Call parse_cmd and hand off execution accordingly
+    Call parse_cmd and hand off execution accordingly
     """
     arguments = parse_cmd()
 

--- a/artorias.py
+++ b/artorias.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Artorias main file"""
+"""Artorias main file, kicks off the rest of the project"""
 
 import logging
 from core.args import parse_cmd
@@ -12,9 +12,11 @@ def main() -> int:
     """
     arguments = parse_cmd()
 
+    # Convert arg from parser/user_input to proper log levels
     log_level = getattr(logging, arguments.log_level.upper())
     logging.basicConfig(filename=arguments.output, level=log_level)
     cmd = arguments.command
+
     if cmd == 'test':
         ret = handle_test(arguments)
     elif cmd == 'scan':

--- a/core/args.py
+++ b/core/args.py
@@ -12,7 +12,9 @@ def parse_cmd() -> argparse.Namespace:
         "subparser": "Choose what to do with Artorias",
         'identify': "Identify hosts on specified subnet",
         'scan': "Run a scanner with default args, manually testing on an IoT host with",
-        'scanHostScan': "Nmap host scan: Searches current network for alive hosts",
+        'scanScans': "Scans to run, either singular or a list of them.",
+        'scanPorts': "Ports that the target has to run scans on.",
+        'scanCredentials': "<user>:<password> combintation to use on targets authenticated services.",
         'test': "Run a series of scans, preconfigured to test aspects of an IoT host." \
                 + "The recommended option to using this scanner/framework",
         'testAll': "Run all tests possible",
@@ -22,13 +24,26 @@ def parse_cmd() -> argparse.Namespace:
         'testPass': 'Password to use for authticating with services. Must be supplied with username.',
         'testOutput': 'Log file to output logging information to. Default is scanner.log',
         'testLog': 'Lowest log level to display. Set to debug to output debug messages to file.',
-        'service': "Start WebInterface Service to show/represent results"
+
     }
-    # TODO remove later
-    print('Right now only test argument is implemented. Args in test should work.')
-    print('No args supplied uses host scan to gather hosts, or use target arg.')
 
     parser = argparse.ArgumentParser()
+
+    # Command agnostic arguments
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default="scanner.log",
+        help=msg['testOutput'])
+    parser.add_argument(
+        "-l",
+        "--log_level",
+        type=str,
+        default="info",
+        choices=["info", "debug", "warning", "error"],
+        help=msg['testLog'])
+
     subparser = parser.add_subparsers(
         dest="command",
         help=msg['subparser'])
@@ -39,9 +54,21 @@ def parse_cmd() -> argparse.Namespace:
         "scan",
         help=msg['scan'])
     scan.add_argument(
-        "--hostScan",
-        action="store_true",
-        help=msg['scanHostScan'])
+        "-s",
+        "--scans",
+        type=list,
+        choices=['nikto', 'hydra', 'zap-spider'],
+        help=msg['scanScans'])
+    scan.add_argument(
+        "-p",
+        "--ports",
+        type=list,
+        help=msg['scanPorts'])
+    scan.add_argument(
+        "-c",
+        "--credentials",
+        type=str,
+        help=msg['scanCredentials'])
 
     # artorias test ${args}
     test = subparser.add_parser(
@@ -78,18 +105,5 @@ def parse_cmd() -> argparse.Namespace:
         type=str,
         default=None,
         help=msg['testPass'])
-    test.add_argument(
-        "-o",
-        "--output",
-        type=str,
-        default="scanner.log",
-        help=msg['testOutput'])
-    test.add_argument(
-        "-l",
-        "--log_level",
-        type=str,
-        default="info",
-        choices=["info", "debug", "warning", "error"],
-        help=msg['testLog'])
 
     return parser.parse_args()

--- a/core/args.py
+++ b/core/args.py
@@ -15,6 +15,7 @@ def parse_cmd() -> argparse.Namespace:
         'scanScans': "Scans to run, either singular or a list of them.",
         'scanPorts': "Ports that the target has to run scans on.",
         'scanCredentials': "<user>:<password> combintation to use on targets authenticated services.",
+        'scanTarget': "Target(s) to run tests on",
         'test': "Run a series of scans, preconfigured to test aspects of an IoT host." \
                 + "The recommended option to using this scanner/framework",
         'testAll': "Run all tests possible",
@@ -44,6 +45,7 @@ def parse_cmd() -> argparse.Namespace:
         choices=["info", "debug", "warning", "error"],
         help=msg['testLog'])
 
+    # Separate args by the command they are applicable for
     subparser = parser.add_subparsers(
         dest="command",
         help=msg['subparser'])
@@ -56,19 +58,30 @@ def parse_cmd() -> argparse.Namespace:
     scan.add_argument(
         "-s",
         "--scans",
-        type=list,
-        choices=['nikto', 'hydra', 'zap-spider'],
+        type=str,
+        nargs='+',
+        choices=['nikto_scan', 'hydra_scan', 'zap_spider_scan'],
         help=msg['scanScans'])
     scan.add_argument(
         "-p",
         "--ports",
-        type=list,
+        type=str,
+        nargs='+',
+        required=True,
         help=msg['scanPorts'])
     scan.add_argument(
         "-c",
         "--credentials",
         type=str,
         help=msg['scanCredentials'])
+    scan.add_argument(
+        "-t",
+        "--target",
+        nargs='+',
+        type=str,
+        default=[],
+        required=True,
+        help=msg['scanTarget'])
 
     # artorias test ${args}
     test = subparser.add_parser(

--- a/core/host.py
+++ b/core/host.py
@@ -1,6 +1,7 @@
 # Contains Host Object Info
 
 from core.result import Results
+from settings import WEB_PORTS, AUTH_PORTS
 
 class Host():
     """
@@ -14,7 +15,7 @@ class Host():
 
         self._services = None
 
-        self._open_ports = []
+        self._open_ports = None
 
         self._nikto_result = None
 
@@ -65,8 +66,8 @@ class Host():
         """
         Determine if host has a port that is commonly known as a web interface
         """
-        for service in self._services.get_results()['ports']:
-            if service['id'] in ('80', '443', '8080'):
+        for port in self._open_ports:
+            if port in WEB_PORTS:
                 return True
         return False
 
@@ -75,8 +76,7 @@ class Host():
         Determine if host has ports/services suitable to run brute force against for
         credentials.
         """
-        auth = ['80', '443', '21', '22', '23']
-        for service in self._services.get_results()['ports']:
-            if service['id'] in auth:
+        for port in self._open_ports:
+            if port in AUTH_PORTS:
                 return True
         return False

--- a/core/scans/nikto_scan.py
+++ b/core/scans/nikto_scan.py
@@ -8,7 +8,7 @@ from core.result import Results
 from core.scan import Scan
 from core.utils import xml2json
 from log import low
-from settings import SCAN_OUTPUT_DIR, DATE_ARGS
+from settings import SCAN_OUTPUT_DIR, DATE_ARGS, WEB_PORTS
 
 class NiktoScan(Scan):
 
@@ -22,11 +22,16 @@ class NiktoScan(Scan):
         return self.target.has_web_interface()
 
     def set_config(self) -> None:
-        self.user = self.target.get_credentials()['user']
-        self.password = self.target.get_credentials()['passwd']
+        try:
+            self.user = self.target.get_credentials()['user']
+            self.password = self.target.get_credentials()['passwd']
+        except KeyError:
+            low("User/Pass not supplied for nikto scan, running without credentials.")
+            self.user = ""
+            self.password = ""
 
         for temp in self.target.get_open_ports():
-            if temp in ('80', '8080', '443'):
+            if temp in WEB_PORTS:
                 self.port = temp
                 break
 

--- a/core/scans/zap_spider_scan.py
+++ b/core/scans/zap_spider_scan.py
@@ -25,8 +25,13 @@ class ZapSpiderScan(Scan):
         return self.target.has_web_interface()
 
     def set_config(self) -> None:
-        self.user = self.target.get_credentials()['user']
-        self.password = self.target.get_credentials()['passwd']
+        try:
+            self.user = self.target.get_credentials()['user']
+            self.password = self.target.get_credentials()['passwd']
+        except KeyError:
+            low("No USER/PASS provided for zap scan, running without them.")
+            self.user = ""
+            self.password = ""
 
         for temp in self.target.get_open_ports():
             if temp in ('80', '8080', '443'):

--- a/settings.py
+++ b/settings.py
@@ -8,3 +8,9 @@ WORD_LIST = 'scanners/rockyou.txt'
 
 # Arguments for datetime.now().strftime calls. Can be configured for finer or looser times logged
 DATE_ARGS = '%m-%d_%H-%M-%S'
+
+# Default ports for Web scans
+WEB_PORTS = ('80', '443', '8080')
+
+# Default ports for Auth scans w/ Hydra
+AUTH_PORTS = ('22', '23', '80', '443')

--- a/unittests/test_core_host.py
+++ b/unittests/test_core_host.py
@@ -10,23 +10,23 @@ class TestCoreHost(unittest.TestCase):
         self.host._services = MagicMock()
 
     def test_has_web_interface(self):
-        self.host._services.get_results.return_value = {'ports': [{'id': '80'}]}
+        self.host._open_ports = ['80']
 
         ret = self.host.has_web_interface()
         self.assertEquals(ret, True)
 
-        self.host._services.get_results.return_value = {'ports': [{'id': '22'}]}
+        self.host._open_ports = ['22']
 
         ret = self.host.has_web_interface()
         self.assertEquals(ret, False)
 
     def test_has_auth_surface(self):
-        self.host._services.get_results.return_value = {'ports': [{'id': '22'}]}
+        self.host._open_ports = ['22']
 
         ret = self.host.has_auth_surface()
         self.assertEquals(ret, True)
 
-        self.host._services.get_results.return_value = {'ports': [{'id': '8080'}]}
+        self.host._open_ports = ['8080']
 
         ret = self.host.has_auth_surface()
         self.assertEquals(ret, False)

--- a/unittests/test_core_scans.py
+++ b/unittests/test_core_scans.py
@@ -4,38 +4,4 @@ from core.scanning import *
 
 class TestCoreScanning(unittest.TestCase):
 
-    @patch('core.scanning.low')
-    @patch('core.scanning.Popen')
-    @patch('core.scanning.datetime')
-    def test_host_scan(self, mock_time, mock_popen, mock_low):
-        mock_time.now.return_value.strftime.return_value = 'MockTime'
-        ret = host_scan('MockSubnet')
-
-        expected_calls = [
-            call(['nmap', 'MockSubnet', '-sn', '-oX', 'core/outputs/host_scanMockTime.xml'],
-                 stderr=-3, stdout=-3),
-            call().wait()
-        ]
-        for c in expected_calls:
-            self.assertIn(c, mock_popen.mock_calls)
-
-        self.assertEquals(mock_low.call_count, 2)
-        self.assertEquals(ret, 'core/outputs/host_scanMockTime.xml')
-
-    @patch('core.scanning.low')
-    @patch('core.scanning.Popen')
-    @patch('core.scanning.datetime')
-    def test_skipfish_scan(self, mock_date, mock_popen, mock_low):
-        mock_date.now.return_value.strftime.return_value = 'MockTime'
-
-        ret = skipfish_scan('MockHost', 'MockPort')
-        expected_calls = [
-            call(['skipfish', '-o', 'core/outputs/skipfish_scanMockPort_MockTime.xml',
-                  'MockHost']),
-            call().wait()
-        ]
-        for c in expected_calls:
-            self.assertIn(c, mock_popen.mock_calls)
-
-        self.assertEquals(ret, 'core/outputs/skipfish_scanMockPort_MockTime.xml')
-
+    pass


### PR DESCRIPTION
implement scan arg. adjust run_scans in core/utils to force a scan to run if prerequisites aren't met. 

Reasoning for this is that the scan command will be more explicit, and require information from the user such as the port and host to scan. Because the user is being so explicit, I think it would be annoying for them to have to manually update the settings.py file to run a nikto scan, for example, on a port that is not in the WEB_PORTS variable. So, running scans manually will attempt to force the scan to run, even if prerequisites are not met.